### PR TITLE
Style/HashSyntax: re-enable for ruby 3.1 shorthand syntax

### DIFF
--- a/rubocop-iknow.gemspec
+++ b/rubocop-iknow.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name     = 'rubocop-iknow'
-  s.version  = '0.0.11'
-  s.date     = '2022-12-15'
+  s.version  = '0.0.12'
+  s.date     = '2023-05-29'
   s.summary  = 'Rubocop Configuration used with iKnow Projects'
   s.authors  = ['iKnow Team']
   s.email    = 'edge@iknow.jp'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -169,7 +169,9 @@ Style/HashEachMethods:
 Style/HashSyntax:
   # We explicitly choose to use rocket style syntax when the Hash is being used
   # to represent some other sort of data structure (trees, pairs, etc).
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: no_mixed_keys
+  EnforcedShorthandSyntax: always
 
 Style/HashTransformKeys:
   Enabled: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -172,6 +172,7 @@ Style/HashSyntax:
   Enabled: true
   EnforcedStyle: no_mixed_keys
   EnforcedShorthandSyntax: always
+  Severity: error
 
 Style/HashTransformKeys:
   Enabled: true


### PR DESCRIPTION
The justification remains the same, but it's useful to see when it's
possible to use the ruby 3.1 shorthand syntax, which is a feature of
the same checker. Instead of disabling it entirely, enable it in a
compatible mode.