### PR TITLE
Layout/TrailingEmptyLines: increase severity 

### DIFF
--- a/rubocop-iknow.gemspec
+++ b/rubocop-iknow.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name     = 'rubocop-iknow'
-  s.version  = '0.0.10'
-  s.date     = '2022-09-05'
+  s.version  = '0.0.11'
+  s.date     = '2022-12-15'
   s.summary  = 'Rubocop Configuration used with iKnow Projects'
   s.authors  = ['iKnow Team']
   s.email    = 'edge@iknow.jp'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -48,6 +48,9 @@ Layout/MultilineMethodDefinitionBraceLayout:
 Layout/SpaceInsideRangeLiteral:
   Enabled: false
 
+Layout/TrailingEmptyLines:
+  Severity: error
+
 Layout/TrailingWhitespace:
   Severity: error
 


### PR DESCRIPTION
Intended to catch any files that do not have a trailing newline. This is something well behaved editors do automatically, but apparently there are some that don't.