### PR TITLE
Forbid Date.today

### DIFF
--- a/lib/custom_cops/forbid_date_today.rb
+++ b/lib/custom_cops/forbid_date_today.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+return unless defined?(::RuboCop)
+
+module CustomCops
+  class ForbidDateToday < ::RuboCop::Cop::Base
+    MSG = 'Do not use `Date.today`, replace with `Date.current`'
+
+    def on_send(node)
+      if node.source.include?('Date.today') && node.receiver.const_name == 'Date' && node.method_name == 'today'
+        add_offense(node)
+      end
+    end
+  end
+end

--- a/rubocop-iknow.gemspec
+++ b/rubocop-iknow.gemspec
@@ -2,12 +2,12 @@
 
 Gem::Specification.new do |s|
   s.name     = 'rubocop-iknow'
-  s.version  = '0.0.11'
+  s.version  = '0.0.12'
   s.date     = '2022-12-15'
   s.summary  = 'Rubocop Configuration used with iKnow Projects'
   s.authors  = ['iKnow Team']
   s.email    = 'edge@iknow.jp'
-  s.files    = ['rubocop.yml']
+  s.files    = ['rubocop.yml', 'lib/custom_cops/forbid_date_today.rb']
   s.homepage =
     'https://github.com/iknow/rubocop-iknow'
   s.license = 'MIT'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,3 +1,6 @@
+require:
+    - ./lib/custom_cops/forbid_date_today.rb
+
 AllCops:
   TargetRubyVersion: 2.5
   NewCops: enable
@@ -286,3 +289,8 @@ Style/WhileUntilModifier:
 
 Style/WordArray:
   Enabled: false
+
+# Date.today is incompatible with Rails time zones and Date.tomorrow/yesterday
+CustomCops/ForbidDateToday:
+  Enabled: true
+  Severity: error


### PR DESCRIPTION
Ruby's Date.today is incompatible with Rails timezones and its Date.yesterday/tomorrow. Use Rails' Date.current instead.